### PR TITLE
Fixing deprecated conversion from string

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ RFTransmitter transmitter(OUTPUT_PIN, NODE_ID);
 void setup() {}
 
 void loop() {
-  char *msg = "Hello World!";
+  const char *msg = "Hello World!";
   transmitter.send((byte *)msg, strlen(msg) + 1);
 
   delay(5000);
-  
+
   transmitter.resend((byte *)msg, strlen(msg) + 1);
 }
 ```


### PR DESCRIPTION
The current version of C++ used currently by the Arduino IDE do not support this kind of conversion any more.

Reference: _[Stackoverflow: C++ deprecated conversion from string constant to 'char*'](https://stackoverflow.com/questions/1524356/c-deprecated-conversion-from-string-constant-to-char)_