### PR TITLE
Update digitalWrite to use new api

### DIFF
--- a/RFTransmitter.h
+++ b/RFTransmitter.h
@@ -36,16 +36,34 @@ class RFTransmitter {
     unsigned int backoffDelay;
     // How often a reliable package is resent
     byte resendCount;
-    byte lineState;
+    #if (ARDUINO_API_VERSION >= 10000)
+      PinStatus lineState;
+    #else
+      byte lineState;
+    #endif
+
+    #if (ARDUINO_API_VERSION >= 10000)
+      PinStatus switchStatus(PinStatus p) {
+        return (p == HIGH) ? LOW : HIGH;
+      }
+    #endif
 
     void send0() {
-      lineState = !lineState;
+      #if (ARDUINO_API_VERSION >= 10000)
+        lineState = switchStatus(lineState);
+      #else
+        lineState = !lineState;
+      #endif
       digitalWrite(outputPin, lineState);
       delayMicroseconds(pulseLength << 1);
     }
 
     void send1() {
-      digitalWrite(outputPin, !lineState);
+      #if (ARDUINO_API_VERSION >= 10000)
+        digitalWrite(outputPin, switchStatus(lineState));
+      #else
+        digitalWrite(outputPin, !lineState);
+      #endif
       delayMicroseconds(pulseLength);
       digitalWrite(outputPin, lineState);
       delayMicroseconds(pulseLength);


### PR DESCRIPTION
I've got one of the new Arduino Nano Every boards but your library wouldn't compile b/c it uses the new digitalWrite api.  This issue is discussed here.

https://github.com/arduino/ArduinoCore-API/issues/25

This change allows this library to compile with the new api.  I've tested this with this with the Nano Every, but not with an Uno or anything else (No access to hardware).  Although the code should be equivalent for the older boards, feel free to give it a test if you have some of the older hardware.

Thanks for the great lib btw, it's a nice compromise between RadioHead and RCSwitch